### PR TITLE
.npmignore for a lightweight package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.editorconfig
+.gitattributes
+.gitignore
+.jshintrc
+.travis.yml
+haz.jpg
+test.js


### PR DESCRIPTION
Especially with npm's deep dependency trees, keeping the footprint a package small is important. The `.npmignore` files leaves out all unnecessary files when publishing to the registry.

BTW: Does this package support IE11 touch events?
